### PR TITLE
Develop

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -29,4 +29,4 @@ lib_deps =
     ${env.lib_deps}
     https://github.com/Sensirion/arduino-i2c-scd4x
 ; upload_port = COM11
-; monitor_port = ${env:m5atom.upload_port}
+; monitor_port = ${env:atom-babies-co2-checker.upload_port}

--- a/platformio.ini
+++ b/platformio.ini
@@ -2,7 +2,7 @@
 default_envs = atom-babies-co2-checker
 
 [env]
-platform = espressif32
+platform = espressif32@3.5.0
 framework = arduino
 board = m5stack-atom
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,13 +11,13 @@ monitor_filters = time, esp32_exception_decoder
 upload_speed = 1500000
 board_build.f_flash = 80000000L
 
-src_filter = +<*.cpp> +<*.h>
 lib_ldf_mode = deep
 
 build_type = release
 ; build_type = debug
 build_flags =
     ; -DDEBUG
+build_src_filter = +<*.cpp> +<*.h>
 
 lib_deps =
     m5stack/M5Atom

--- a/platformio.ini
+++ b/platformio.ini
@@ -2,7 +2,8 @@
 default_envs = atom-babies-co2-checker
 
 [env]
-platform = espressif32@3.5.0
+platform = espressif32
+platform_packages = framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32/#2.0.0
 framework = arduino
 board = m5stack-atom
 

--- a/src/CO2Checker.h
+++ b/src/CO2Checker.h
@@ -27,7 +27,7 @@ public:
     CO2Checker(void);
     virtual ~CO2Checker(void);
 
-    virtual bool begin(TwoWire& wire = Wire1);
+    virtual bool begin(TwoWire& wire = Wire);
     virtual bool update(AtomBabies& babies);
 
     virtual bool startPeriodicMeasurement(bool isLowPower = true);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,3 @@
-#include <Wire.h>
-
 #include "AtomBabies.h"
 #include "CO2Checker.h"
 
@@ -10,8 +8,7 @@ CO2Checker checker;
 
 void setup(void) {
     babies.begin();
-
-    checker.begin(Wire);
+    checker.begin();
     M5.update();
     if (M5.Btn.isPressed()) {
         babies.fill(CRGB::Green);


### PR DESCRIPTION
* `monitor_port`に指定していた環境名のtypoを修正
* `platform`をespressif32（最新）にして，`platform_packages`にarduino-esp32 v2.0.0を指定（2.0.1以降だと動かないため）
* `CO2Checker.begin()`のデフォルト引数を`Wire1`から`Wire`に変更（ATOM Matrixは`Wire1`をIMUで使っている）
